### PR TITLE
Bug fix os.path.isdir() to os.path.isfile() in coco.py

### DIFF
--- a/sotabencheval/object_detection/coco.py
+++ b/sotabencheval/object_detection/coco.py
@@ -124,7 +124,7 @@ class COCOEvaluator(object):
         :param annFile: path of the annotations file
         :return: void - extracts the archive
         """
-        if not os.path.isdir(annFile):
+        if not os.path.isfile(annFile):
             if "2017" in annFile:
                 annotations_dir_zip = os.path.join(
                     self.root, "annotations_train%s2017.zip" % self.split


### PR DESCRIPTION
Current code produces an error when the file is present, as the current code is looking for a directory. Fix corrects this.